### PR TITLE
z2_plus: Pin all decommonized blobs

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1,50 +1,50 @@
-# Audio ACDB
-vendor/etc/acdbdata/MTP/MTP_Speaker_cal.acdb
-vendor/etc/acdbdata/MTP/MTP_General_cal.acdb
-vendor/etc/acdbdata/MTP/MTP_Handset_cal.acdb
-vendor/etc/acdbdata/MTP/MTP_Headset_cal.acdb
-vendor/etc/acdbdata/MTP/MTP_Global_cal.acdb
-vendor/etc/acdbdata/MTP/MTP_Hdmi_cal.acdb
-vendor/etc/acdbdata/MTP/MTP_Bluetooth_cal.acdb
+# Audio ACDB - from z2_plus - OPR1.170623.032.4.0.199_181018
+vendor/etc/acdbdata/MTP/MTP_Speaker_cal.acdb|40ce9f6df7e42530ab55fa2412281ffd3b40822d
+vendor/etc/acdbdata/MTP/MTP_General_cal.acdb|476ad92e2e5e1df46d19161f33225a2b04b856eb
+vendor/etc/acdbdata/MTP/MTP_Handset_cal.acdb|c1c7bc9892997c13fbdb66c127d1a18d37ab2f0c
+vendor/etc/acdbdata/MTP/MTP_Headset_cal.acdb|6f82ff71637cff91712510dc607647c5c8b7b83c
+vendor/etc/acdbdata/MTP/MTP_Global_cal.acdb|2cd48125ec3343bc813bb18e8e5c473b22661310
+vendor/etc/acdbdata/MTP/MTP_Hdmi_cal.acdb|afdc6c398a71c139abcfef880a53c1600f3ed3ab
+vendor/etc/acdbdata/MTP/MTP_Bluetooth_cal.acdb|442a76790dcb364a02fc9ac10535dec9d4d9bbdf
 
-# Camera actuator
-vendor/lib/libactuator_dw9767.so
+# Camera actuator - from z2_plus - OPR1.170623.032.4.0.199_181018
+vendor/lib/libactuator_dw9767.so|9f6792ef634727ea3f08c7acc7f01b782e9a5fc7
 
-# Camera chromatix
-vendor/lib/libchromatix_s5k2m8sx_common.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_hfr_120.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_hfr_60.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_hfr_90.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_liveshot.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_preview.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_snapshot.so
-vendor/lib/libchromatix_s5k2m8sx_cpp_video.so
-vendor/lib/libchromatix_s5k2m8sx_default_preview_dw9767.so
-vendor/lib/libchromatix_s5k2m8sx_default_video_dw9767.so
-vendor/lib/libchromatix_s5k2m8sx_default_video.so
-vendor/lib/libchromatix_s5k2m8sx_hfr_120_dw9767.so
-vendor/lib/libchromatix_s5k2m8sx_hfr_120.so
-vendor/lib/libchromatix_s5k2m8sx_hfr_60_dw9767.so
-vendor/lib/libchromatix_s5k2m8sx_hfr_60.so
-vendor/lib/libchromatix_s5k2m8sx_hfr_90_dw9767.so
-vendor/lib/libchromatix_s5k2m8sx_hfr_90.so
-vendor/lib/libchromatix_s5k2m8sx_liveshot.so
-vendor/lib/libchromatix_s5k2m8sx_postproc.so
-vendor/lib/libchromatix_s5k2m8sx_preview.so
-vendor/lib/libchromatix_s5k2m8sx_snapshot.so
-vendor/lib/libchromatix_s5k2m8sx_zsl_preview_dw9767.so
-vendor/lib/libchromatix_s5k2m8sx_zsl_video_dw9767.so
+# Camera chromatix - from z2_plus - OPR1.170623.032.4.0.199_181018
+vendor/lib/libchromatix_s5k2m8sx_common.so|fac9335897f14269818efbcc29bae85f251dc703
+vendor/lib/libchromatix_s5k2m8sx_cpp_hfr_120.so|d691f7cb32f3b50680ca7d74c35cd9cbd2b1ea3d
+vendor/lib/libchromatix_s5k2m8sx_cpp_hfr_60.so|439a4c92804b6aa9b1d0d88ab068834c3d34efc1
+vendor/lib/libchromatix_s5k2m8sx_cpp_hfr_90.so|2391da37688eca11556d3af4737e37b04130a04f
+vendor/lib/libchromatix_s5k2m8sx_cpp_liveshot.so|0da7ee003368c56a3041fb83dad1e68f9e710bb9
+vendor/lib/libchromatix_s5k2m8sx_cpp_preview.so|ac40d5f1b01dd42cf1290560965e2c03cb866245
+vendor/lib/libchromatix_s5k2m8sx_cpp_snapshot.so|24a663162eff6ca50d053c49a7054c3fb0ff09fc
+vendor/lib/libchromatix_s5k2m8sx_cpp_video.so|bf7fe8911a23afbddecf38001d2ba20ff1e82ebe
+vendor/lib/libchromatix_s5k2m8sx_default_preview_dw9767.so|9de12025a7da70d7d4c63f6bc26d347af74d89f1
+vendor/lib/libchromatix_s5k2m8sx_default_video_dw9767.so|9d9a4b2f26e23f5739f9f665e7b2845eb204d1cc
+vendor/lib/libchromatix_s5k2m8sx_default_video.so|761663e7fcd8de8d1ad998e46461eb4c6f216885
+vendor/lib/libchromatix_s5k2m8sx_hfr_120_dw9767.so|273b7c6463a260f2422e0f609292b72cef86d5ef
+vendor/lib/libchromatix_s5k2m8sx_hfr_120.so|64bc2fbcc68f4be26003e7ab98bbd407fc381eba
+vendor/lib/libchromatix_s5k2m8sx_hfr_60_dw9767.so|fac378b57980e0c90489684dcea9ddc5e1191e15
+vendor/lib/libchromatix_s5k2m8sx_hfr_60.so|ad2cff3da21ce4daadaafa49c34e190f18c9518b
+vendor/lib/libchromatix_s5k2m8sx_hfr_90_dw9767.so|dba5e2614cd2d863ef0bff2c8928550a276b087c
+vendor/lib/libchromatix_s5k2m8sx_hfr_90.so|afa3abbc2f27d844b3143b388a1aa061c2bcda32
+vendor/lib/libchromatix_s5k2m8sx_liveshot.so|f5fc0030a7b7d0bf756f8e904dc71325c3377846
+vendor/lib/libchromatix_s5k2m8sx_postproc.so|656605162345755105e6e7dbb75f37b0c6f20f49
+vendor/lib/libchromatix_s5k2m8sx_preview.so|a749d8a8e3f0f81bc8cd9c215a69c8225f1eee24
+vendor/lib/libchromatix_s5k2m8sx_snapshot.so|cac63771096543a0120f23329de2b57a61c7323f
+vendor/lib/libchromatix_s5k2m8sx_zsl_preview_dw9767.so|e4d5e1d7b515ac977fee8637531185a3341eeed1
+vendor/lib/libchromatix_s5k2m8sx_zsl_video_dw9767.so|703c956388e1393693b22f831106e978db6da0b1
 
-# Camera configs
-etc/camera/msm8996_camera.xml:vendor/etc/camera/msm8996_camera.xml
-etc/camera/s5k2m8sx_chromatix.xml:vendor/etc/camera/s5k2m8sx_chromatix.xml
+# Camera configs - from z2_plus - OPR1.170623.032.4.0.199_181018
+etc/camera/msm8996_camera.xml:vendor/etc/camera/msm8996_camera.xml|427dfce1771b9b6924f7067c9e8d2421678836bd
+etc/camera/s5k2m8sx_chromatix.xml:vendor/etc/camera/s5k2m8sx_chromatix.xml|570ac2d28ff639e1b5c18a28395de0520158e55d
 
-# Camera eeproms
-vendor/lib/libmmcamera_onsemi_cat24c64_eeprom.so
+# Camera eeproms - from z2_plus - OPR1.170623.032.4.0.199_181018
+vendor/lib/libmmcamera_onsemi_cat24c64_eeprom.so|281544658c71f99e2791e8ab85fb4f3d02c7abef
 
-# Camera sensors
-vendor/lib/libmmcamera_ov8865.so
-vendor/lib/libmmcamera_s5k2m8sx.so
+# Camera sensors - from z2_plus - OPR1.170623.032.4.0.199_181018a_ov8865.so
+vendor/lib/libmmcamera_ov8865.so|fe23ab9aa92c7528ebadf8a042d2f1a5933e3e4b
+vendor/lib/libmmcamera_s5k2m8sx.so|41f6dd85b55b6320bcd4447900d7b4a03ecca9c0
 
-# Sensors
-vendor/etc/sensors/sensor_def_qcomdev.conf
+# Sensors - from z2_plus - OPR1.170623.032.4.0.199_181018
+vendor/etc/sensors/sensor_def_qcomdev.conf|02f8f2f0ede4d62f733938fd4971bb1fb3dc2acd


### PR DESCRIPTION
* The main blobs source is to be considered z2_row since its latest
  build is more updated than z2_plus', so pin all these blobs

Change-Id: I9c110444e0b8998b6520874ebc1b11af36242b9b